### PR TITLE
Created wrapper functions for IL7 and IL9

### DIFF
--- a/ckine/model.py
+++ b/ckine/model.py
@@ -135,29 +135,29 @@ def dy_dt(y, t, IL2, IL15, IL7, IL9, k4fwd, k5rev, k6rev, k13fwd, k15rev, k17rev
 
 def dy_dt_IL2_wrapper(y, t, IL2, k4fwd, k5rev, k6rev):
     ''' Wrapper for dy_dt that is specific to IL2 '''
-    # need to add zero's for the IL15 elements of y0 in dy_dt
-    # TODO: Unit test of wrapper
-    z = np.zeros(16) # set the initial concentration of IL15, IL7 and IL9 receptors to 0
-    # need to combine y and z as a numpy array
-    ys = np.concatenate((y, z), axis=0)
+    ys = np.zeros(26)
+    ys[0] = y[0] # set the first value in y to be IL2Ra
+    ys[1] = y[1] # set the second value in y to be IL2Rb
+    ys[2] = y[2] # set the third value in y to be gamma chain
     ret_val = dy_dt(ys, t, IL2, 0., 0., 0., k4fwd, k5rev, k6rev, 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.) # set the IL15, IL7 and IL9 reaction rates to 1
     return ret_val[0:10]
 
 def dy_dt_IL9_wrapper(y, t, IL9, k29rev, k30rev, k31rev):
-    z = np.zeros(24)
-    ys = np.concatenate((z,y), axis=0)
+    ys = np.zeros(26)
+    ys[2] = y[1] # set the second value of y to be the gamma chain
+    ys[22] = y[0] # set the first value of y to be IL9R
     ret_val = dy_dt(ys, t, 0., 0., 0., IL9, 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., k29rev, k30rev, k31rev)
     ret_values = np.concatenate((ret_val[2:3], ret_val[22:26]), axis=0) # need to use notation [2:3] so that value is stored in array instead of float
     return ret_values
 
 def dy_dt_IL7_wrapper(y, t, IL7, k25rev, k26rev, k27rev):
-    x = np.zeros(18)
-    z = np.zeros(4)
-    ys = np.concatenate((x,y,z), axis=0)
+    ys = np.zeros(26)
+    ys[2] = y[1] # set the second value of y to be the gamma chain
+    ys[18] = y[0] # set the first value of y to be IL7Ra
     ret_val = dy_dt(ys, t, 0., 0., IL7, 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., k25rev, k26rev, k27rev, 1., 1., 1.)
     ret_values = np.concatenate((ret_val[2:3], ret_val[18:22]), axis=0)
     return ret_values
 
 dy_dt_IL7_wrapper([1., 1., 1., 1.], 2., 5., 2., 2., 2.)
-dy_dt_IL9_wrapper([1., 1., 1., 1.], 2., 5., 2., 2., 2.)
-dy_dt_IL2_wrapper([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.], 2., 5., 2., 2., 2.)
+dy_dt_IL9_wrapper([1., 1.], 2., 5., 2., 2., 2.)
+dy_dt_IL2_wrapper([1., 1., 1.], 2., 5., 2., 2., 2.)


### PR DESCRIPTION
also cleaned up the IL2 wrapper function through using np.zeros instead of typing out each 0. Fix #28 and Fix #29 