### PR TITLE
IL9 and IL7 wrappers

### DIFF
--- a/ckine/model.py
+++ b/ckine/model.py
@@ -136,28 +136,26 @@ def dy_dt(y, t, IL2, IL15, IL7, IL9, k4fwd, k5rev, k6rev, k13fwd, k15rev, k17rev
 def dy_dt_IL2_wrapper(y, t, IL2, k4fwd, k5rev, k6rev):
     ''' Wrapper for dy_dt that is specific to IL2 '''
     ys = np.zeros(26)
-    ys[0] = y[0] # set the first value in y to be IL2Ra
-    ys[1] = y[1] # set the second value in y to be IL2Rb
-    ys[2] = y[2] # set the third value in y to be gamma chain
+    ys[0:10] = y[0:10] # set the first value in y to be IL2Ra
     ret_val = dy_dt(ys, t, IL2, 0., 0., 0., k4fwd, k5rev, k6rev, 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.) # set the IL15, IL7 and IL9 reaction rates to 1
     return ret_val[0:10]
 
 def dy_dt_IL9_wrapper(y, t, IL9, k29rev, k30rev, k31rev):
     ys = np.zeros(26)
-    ys[2] = y[1] # set the second value of y to be the gamma chain
-    ys[22] = y[0] # set the first value of y to be IL9R
+    ys[2] = y[0] # set the first value of y to be the gamma chain
+    ys[22:26] = y[1:5]
     ret_val = dy_dt(ys, t, 0., 0., 0., IL9, 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., k29rev, k30rev, k31rev)
     ret_values = np.concatenate((ret_val[2:3], ret_val[22:26]), axis=0) # need to use notation [2:3] so that value is stored in array instead of float
     return ret_values
 
 def dy_dt_IL7_wrapper(y, t, IL7, k25rev, k26rev, k27rev):
     ys = np.zeros(26)
-    ys[2] = y[1] # set the second value of y to be the gamma chain
-    ys[18] = y[0] # set the first value of y to be IL7Ra
+    ys[2] = y[0] # set the first value of y to be the gamma chain
+    ys[18:22] = y[1:5] 
     ret_val = dy_dt(ys, t, 0., 0., IL7, 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., k25rev, k26rev, k27rev, 1., 1., 1.)
     ret_values = np.concatenate((ret_val[2:3], ret_val[18:22]), axis=0)
     return ret_values
 
-dy_dt_IL7_wrapper([1., 1., 1., 1.], 2., 5., 2., 2., 2.)
-dy_dt_IL9_wrapper([1., 1.], 2., 5., 2., 2., 2.)
-dy_dt_IL2_wrapper([1., 1., 1.], 2., 5., 2., 2., 2.)
+dy_dt_IL7_wrapper([1., 1., 1., 1., 1.], 2., 5., 2., 2., 2.)
+dy_dt_IL9_wrapper([1., 1., 1., 1., 1.], 2., 5., 2., 2., 2.)
+dy_dt_IL2_wrapper([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.], 2., 5., 2., 2., 2.)


### PR DESCRIPTION
only initial concentrations in the "y" list of each argument are the receptor (IL7Ra and IL9R) and the gamma chain (gc); all other receptor-ligand complex initial concentrations are set to 0.