### PR TITLE
Debug IL2 wrapper unit test

### DIFF
--- a/ckine/tests/test_model.py
+++ b/ckine/tests/test_model.py
@@ -57,11 +57,9 @@ class TestModel(unittest.TestCase):
         self.assertEqual(len(temp[1]), 10)
         
     def test_IL15_wrapper(self):
-        self.t = 50 #Choose to run for 50s, can choose anything
-        self.ts = np.linspace(0.0, self.t,2)
-        self.y0 = np.array([1000.,1000.,1000., 0., 0., 0., 0., 0., 0., 0.]) #Assume starting with 1000 receptors of IL15Ra, IL2Rb, and gc
-        self.mat = np.full((1, 6), 1E-2)
-        self.ys = np.zeros((1,10))
-        self.args = (1., self.mat[0,0], self.mat[0,1], self.mat[0,2], self.mat[0,3], self.mat[0,4], self.mat[0,5])
-        self.temp = odeint(dy_dt_IL15_wrapper, self.y0, self.ts, self.args, mxstep = 6000)
-        self.assertEqual(len(self.temp[1]),10)
+        ts = np.array([0.0, 50.0])
+        y0 = np.array([1000.,1000.,1000., 0., 0., 0., 0., 0., 0., 0.]) #Assume starting with 1000 receptors of IL15Ra, IL2Rb, and gc
+        mat = np.full((1, 6), 1E-2)
+        args = (1., mat[0,0], mat[0,1], mat[0,2], mat[0,3], mat[0,4], mat[0,5])
+        temp = odeint(dy_dt_IL15_wrapper, y0, ts, args, mxstep = 6000)
+        self.assertEqual(len(temp[1]),10)


### PR DESCRIPTION
variables are localized to just one unit test instead of belonging to the entire class (no longer have prefix of self. ). Fix #43